### PR TITLE
Prepare for HttpRequest Uint8List SDK change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.6
+* Prepare for upcoming Dart SDK change whereby `HttpRequest` implements
+  `Stream<Uint8List>` rather than `Stream<List<int>>`.
+
 # 1.0.5
 * Add `toString` to `MockHttpHeaders`.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: mock_request
-version: 1.0.5
+version: 1.0.6
 description: Manufacture dart:io HttpRequests, HttpResponses, HttpHeaders, etc.
 author: Tobe O <thosakwe@gmail.com>
 homepage: https://github.com/thosakwe/mock_request


### PR DESCRIPTION
An upcoming change in the Dart SDK will change `HttpRequest`
from implementing `Stream<List<int>>` to instead implement
`Stream<Uint8List>`.

This forwards-compatible change to `MockHttpRequest` is being
made to allow for a smooth rollout of that SDK breaking change.

dart-lang/sdk#36900